### PR TITLE
fixed get tasks bug (eclipse?)

### DIFF
--- a/src/main/java/com/example/timecapsule/controllers/TaskStopwatchController.java
+++ b/src/main/java/com/example/timecapsule/controllers/TaskStopwatchController.java
@@ -24,7 +24,9 @@ public class TaskStopwatchController {
     @CrossOrigin
     @GetMapping(value = "/tasks")
     @ResponseStatus(HttpStatus.OK)
-    public List<TaskDto> getTasks(long taskTypeId, LocalDate selectedDate) {
+    public List<TaskDto> getTasks(
+    		@RequestParam("taskTypeId") int taskTypeId, 
+    		@RequestParam("selectedDate") LocalDate selectedDate) {
         return taskStopwatchService.getTasks(taskTypeId, selectedDate);
     }
 


### PR DESCRIPTION
Got the following error when running the API:

Name for argument of type [long] not specified

Fixed it by added the @RequestParam attribute to the GetTasks parameters.